### PR TITLE
feat: add cache sync timeout configuration

### DIFF
--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -343,21 +343,7 @@ EOF
   fi
 
   echo_step "waiting for provider to be installed"
-  if ! "${KUBECTL}" wait "provider.pkg.crossplane.io/${PACKAGE_NAME}" --for=condition=healthy --timeout=240s; then
-    echo_error "Provider did not become healthy in time. Dumping logs..."
-    "${KUBECTL}" get all -n crossplane-system
-    "${KUBECTL}" get providerrevision -o wide
-    "${KUBECTL}" get provider -o wide
-    # Get the logs of the provider pod
-    POD_NAME=$("${KUBECTL}" get pods -n crossplane-system -l "pkg.crossplane.io/provider=${PACKAGE_NAME}" -o name)
-    if [ -n "$POD_NAME" ]; then
-      echo "Logs for $POD_NAME:"
-      "${KUBECTL}" logs -n crossplane-system "$POD_NAME" -c package-runtime
-    else
-      echo "No pod found for provider ${PACKAGE_NAME}"
-    fi
-    exit 1
-  fi
+  "${KUBECTL}" wait "provider.pkg.crossplane.io/${PACKAGE_NAME}" --for=condition=healthy --timeout=180s
 }
 
 cleanup_provider() {

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -42,7 +42,7 @@ import (
 func main() {
 	var (
 		app                      = kingpin.New(filepath.Base(os.Args[0]), "SQL support for Crossplane.").DefaultEnvars()
-		debug                    = app.Flag("debug", "Run with debug logging.").Short('d').Bool()
+		debug                    = app.Flag("debug", "Run with debug logging.").Short('d').Envar("DEBUG").Bool()
 		pollInterval             = app.Flag("poll", "Poll interval controls how often an individual resource should be checked for drift.").Default("10m").Duration()
 		syncPeriod               = app.Flag("sync", "How often all resources will be double-checked for drift from the desired state.").Short('s').Default("1h").Duration()
 		leaderElection           = app.Flag("leader-election", "Use leader election for the controller manager.").Short('l').Default("false").Envar("LEADER_ELECTION").Bool()

--- a/examples/deploymentRuntimeConfig.yaml
+++ b/examples/deploymentRuntimeConfig.yaml
@@ -10,7 +10,13 @@ spec:
       selector: {}
       template:
         spec:
-          containers: []
+          containers:
+            - name: package-runtime
+              env:
+                - name: DEBUG
+                  value: "true"
+                - name: CACHE_SYNC_TIMEOUT
+                  value: "5m"
           tolerations:
             - effect: NoSchedule
               key: node.kubernetes.io/role


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Added a configurable cache synchronization timeout to avoid error : 
```
Informer fails to sync, timeout waiting for API
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
